### PR TITLE
Add quest selection pipeline for BlockAssist

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,10 @@ export DISABLE_TELEMETRY=1
 
 ## Additional Quests and Maps
 
-A new **Diamond Fortress** map and corresponding `DiamondQuestGenerator` are available. The quest loads an overpowered structure built from diamond blocks for a fresh challenge. To try it, set the goal generator to `diamond_quest` and ensure the `diamond_fortress` house is present in your dataset.
-An **Emerald Maze** map and `EmeraldQuestGenerator` offer a labyrinth of emerald blocks; use the `emerald_quest` goal generator with the `emerald_maze` house to explore it.
-An **Obsidian Tower** map and `ObsidianQuestGenerator` present an unbreakable challenge with obsidian blocks; set the goal generator to `obsidian_quest` and ensure the `obsidian_tower` house is available.
+When you run `python run.py`, the launcher now prompts you to choose which quest to play before Minecraft starts. Press `ENTER` to stick with the classic BlockAssist build, or choose one of the themed challenges below:
+
+- **Diamond Fortress Quest** (`diamond_quest`) — Loads a fortress built from diamond blocks.
+- **Emerald Maze Quest** (`emerald_quest`) — Drops you into a labyrinth of emerald blocks.
+- **Obsidian Tower Quest** (`obsidian_quest`) — Challenges you with an obsidian structure.
+
+Advanced users can skip the prompt by exporting `BLOCKASSIST_QUEST` (for example, `BLOCKASSIST_QUEST=diamond_quest`) or by passing a Hydra override such as `python -m blockassist.launch goal_generator=emerald_quest`.

--- a/src/blockassist/config.yaml
+++ b/src/blockassist/config.yaml
@@ -5,3 +5,4 @@ num_training_iters: 1
 org_id: ${oc.env:BA_ORG_ID}
 address_eoa: ${oc.env:BA_ADDRESS_EOA}
 address_account: ${oc.env:BA_ADDRESS_ACCOUNT}
+goal_generator: ${oc.env:BLOCKASSIST_QUEST,blockassist}

--- a/src/blockassist/launch.py
+++ b/src/blockassist/launch.py
@@ -131,6 +131,7 @@ async def _main(cfg: DictConfig):
                     address_eoa,
                     checkpoint_dir,
                     human_alone=num_instances == 1,
+                    goal_generator=cfg.get("goal_generator", "blockassist"),
                 )
                 episode_runner.start()
                 await episode_runner.wait_for_end()

--- a/tests/test_episode.py
+++ b/tests/test_episode.py
@@ -118,7 +118,7 @@ class TestEpisodeRunnerTelemetry:
 
         # Create a mock main function that raises KeyboardInterrupt after first call
         call_count = 0
-        def mock_main_side_effect():
+        def mock_main_side_effect(*args, **kwargs):
             nonlocal call_count
             call_count += 1
             if call_count == 1:


### PR DESCRIPTION
## Summary
- prompt players to choose a quest in `python run.py`, forwarding the selection through the environment
- allow the BlockAssist episode config and runner to consume a configurable goal generator
- document the new quest workflow and adjust telemetry tests for the updated runner API

## Testing
- PYTHONPATH=src pytest tests/test_episode.py

------
https://chatgpt.com/codex/tasks/task_e_68cb93249cc88333ab49385e88c6ce43